### PR TITLE
Reduce API cost of superfluous scans (too many on old content, too early on new content)

### DIFF
--- a/src/test/scala/ophan/google/indexing/observatory/model/AvailabilityRecordTest.scala
+++ b/src/test/scala/ophan/google/indexing/observatory/model/AvailabilityRecordTest.scala
@@ -1,0 +1,40 @@
+package ophan.google.indexing.observatory.model
+
+import ophan.google.indexing.observatory.model.AvailabilityRecord.{DelayForFirstCheckAfterContentIsFirstSeenInSitemap, reasonableTimeBetweenChecksForContentAged}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.time.Duration
+import java.time.Duration.{ofHours, ofMinutes, ofSeconds}
+import java.time.temporal.ChronoUnit.SECONDS
+import scala.math.Ordering.Implicits._
+
+class AvailabilityRecordTest extends AnyFlatSpec with Matchers {
+
+  val elapsedTimeAtEachCheck: LazyList[Duration] = LazyList.iterate(DelayForFirstCheckAfterContentIsFirstSeenInSitemap) { accumulatedTime =>
+    accumulatedTime.plus(reasonableTimeBetweenChecksForContentAged(accumulatedTime))
+  }
+
+  def maxNumChecksForContentMissing(duration: Duration): Int = elapsedTimeAtEachCheck.indexWhere(_ > duration)
+
+  it should "not cost too much in API calls, but also check often enough for reasonable detail" in {
+    reasonableTimeBetweenChecksForContentAged(ofSeconds(1)) should
+      (be >= ofMinutes(1) and be <= ofMinutes(3))
+
+    reasonableTimeBetweenChecksForContentAged(ofMinutes(2)) should
+      (be >= ofMinutes(2) and be <= ofMinutes(3))
+
+    reasonableTimeBetweenChecksForContentAged(ofHours(1)) should
+      (be >= ofMinutes(10) and be <= ofMinutes(30))
+
+    maxNumChecksForContentMissing(ofMinutes(1)) shouldBe 1
+
+    maxNumChecksForContentMissing(ofHours(1)) should be <= 12
+    maxNumChecksForContentMissing(ofHours(2)) should be <= 15
+
+    val elapsedTimesAtEachCheck =
+      elapsedTimeAtEachCheck.map(_.truncatedTo(SECONDS).toString.stripPrefix("PT")).take(18).mkString(", ")
+
+    println(s"Elapsed time at each check : $elapsedTimesAtEachCheck")
+  }
+}


### PR DESCRIPTION
Currently we're scanning 3 news sites (BBC, NYT, Daily Mail), and this is [consuming](https://console.cloud.google.com/apis/api/customsearch.googleapis.com/metrics?project=ophan-reborn-2017&pageState=(%22duration%22:(%22groupValue%22:%22P1D%22,%22customValue%22:null))) ~7500 Google Search API calls per day:

![image](https://user-images.githubusercontent.com/52038/198285125-0669c7f6-e025-4b5a-9f87-fabd7d537c57.png)


That's maybe ~2500 calls per day per site, or ~$4500 per site per year in API costs 💸 . That's a fair bit of cash, and there's already interest to add at least 4 other sites (Washpo, Telegraph, Sun, and ABC for Dave Earley in Australia). Reducing costs would be good.

## API cost-saving opportunities

### Content that's been missing a long time

Usually, only a small amount of content is very delayed getting into Google Search results, but when content _is_ delayed, we can expend a lot of quota scanning it. For instance, for content that's missing 1 hour, we can use up to 30 API calls just scanning the content every 2 minutes. However, as the length of time the content is missing increases, the chances that it will suddenly appear become lower, as does our interest in being precise about exactly how long it was missing for. Once content has been missing an hour, a reasonable time between checks to see if it's still missing might be 10 minutes or more. This reasonable time between checks increases the longer the content has been missing. With this update, content missing for 1 hour will take fewer than 12 API calls (reducing cost by 60%), and missing for 2 hours fewer than 15 in total (reducing cost by 75% - do note though that most content is usually not this slow to get into Google Search results!).

### Reducing scans on the majority of content that's only delayed a short time

When things are working well, most News articles _don't_ take a long time getting into Google Search - perhaps less than 3 minutes. I think we'd say anything that took less than 2 minutes would be considered prompt - we're not really interested in establishing delay lower than 2 minutes at this point, so it's probably not worth scanning content less than 2 minutes old - the check is likely to come back 'missing', but it cost us an API call and do we care that it's missing yet?

We scan the sitemap once per minute, so there is a max delay of 1 minute between content being published there and us seeing that it's there. Therefore we can still wait at least 1 more minute after content is first seen in the sitemap before scanning the url.

## Resulting check times

For the fastest possible check times - which won't quite happen in practice, as we only run once per minute - the elapsed time at each check is now :

1M, 3M12S, 5M50S, 9M, 12M48S, 17M22S, 22M50S, 29M24S, 37M17S, 46M45S, 58M6S, 1H11M43S, 1H28M4S, 1H47M41S, 2H11M13S, 2H39M28S, 3H13M22S, 3H54M2S
