### PR TITLE
Add ophan github group as codeowners to google-search-indexing-observatory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @guardian/ophan


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Following the [DevX recommendations](https://github.com/guardian/ophan/pull/url) and the [codeowners documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners), this PR adds a `CODEOWNERS` file to this repo. Check this https://github.com/guardian/ophan/issues/5130#issuecomment-1658107415 for a list of repos owned by the Ophan team.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

That will be tested after merge when a PR is created that should automatically assign `ophan` as reviewers.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Codeowners setup in the `google-search-indexing-observatory` repo.