### PR TITLE
Fix logging of what urls are stored

### DIFF
--- a/src/main/scala/ophan/google/indexing/observatory/AvailabilityUpdaterService.scala
+++ b/src/main/scala/ophan/google/indexing/observatory/AvailabilityUpdaterService.scala
@@ -27,14 +27,7 @@ case class AvailabilityUpdaterService(
       storageF = dataStore.storeNewRecordsFor(sitemapDownload, existingRecordsByUri.keySet)
       updatedAvailabilityReports <- checkMostUrgentOf(existingRecordsByUri, sitemapDownload.site)
       _ <- storageF // ...make sure storing new records has completed before we terminate
-    } yield {
-//      val unchangedRecordsForContentThatIsKnownToBeFine: Map[URI, AvailabilityRecord] = {
-//        val urisOfContentThatIsKnownToBeFine = existingRecordsThatDoNotNeedCheckingRightNow.map(_.uri)
-//        existingRecordsByUri.view.filterKeys(urisOfContentThatIsKnownToBeFine)
-//      }.toMap
-      updatedAvailabilityReports
-//      unchangedRecordsForContentThatIsKnownToBeFine ++ updatedAvailabilityReports
-    }
+    } yield updatedAvailabilityReports
   }
 
   def checkMostUrgentOf(

--- a/src/main/scala/ophan/google/indexing/observatory/DataStore.scala
+++ b/src/main/scala/ophan/google/indexing/observatory/DataStore.scala
@@ -27,15 +27,13 @@ case class DataStore() extends Logging {
 
   def storeNewRecordsFor(sitemapDownload: SitemapDownload, alreadyKnownUris: Set[URI]): Future[Unit] = {
     val urisNotSeenBefore = sitemapDownload.allUris -- alreadyKnownUris
-    println(s"urisNotSeenBefore=$urisNotSeenBefore site=${sitemapDownload.site}")
-    logger.info(Map(
-      "site" -> sitemapDownload.site.url,
-      "site.sitemap.uris.all" -> sitemapDownload.allUris.size,
-      "site.sitemap.uris.old" -> alreadyKnownUris.size,
-      "site.sitemap.uris.new" -> urisNotSeenBefore.size
-    ), s"Storing ${urisNotSeenBefore.size} new uris for ${sitemapDownload.site.url}")
-    println("I would expect to see that logging new uris")
     if (urisNotSeenBefore.isEmpty) Future.successful(()) else {
+      logger.info(Map(
+        "site" -> sitemapDownload.site.url,
+        "sitemap.uris.all" -> sitemapDownload.allUris.size,
+        "sitemap.uris.old" -> alreadyKnownUris.size,
+        "sitemap.uris.new" -> urisNotSeenBefore.size
+      ), s"Storing ${urisNotSeenBefore.size} new uris for ${sitemapDownload.site.url}. Sample: ${urisNotSeenBefore.take(2).mkString(",")}")
       scanamoAsync.exec(
         table.putAll(urisNotSeenBefore.map(uri => AvailabilityRecord(uri, sitemapDownload.timestamp)))
       )


### PR DESCRIPTION
While trying to debug why https://github.com/guardian/ophan/pull/5560 hadn't fixed the big gap in data seen on 25th September, I tried to analyse the logging of how many new urls were being stored to dynamodb, but couldn't, because that particualr log line mysteriously wasn't visible anywhere in the [ELK](https://logs.gutools.co.uk/s/ophan/goto/4e86eda0-5dea-11ee-87e8-6b5e97480045):

It turns out that the logging was getting rejected at the stage of ingestion by the ELK - it _was_ being successfully written out as text to [Cloudwatch Logs](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/%2Faws%2Flambda%2Fophan-PROD-google-search-i-scheduledLambda8A84450D-YaBDtsuYvFLP/log-events/2023%2F09%2F28%2F[%24LATEST]68633a68afe34703a8f60893d32b3482?start=PT3H):

<img width="1424" alt="image" src="https://github.com/guardian/google-search-indexing-observatory/assets/52038/f63764b5-210f-49b3-ba5e-a9ff75e0a8ea">

```
{
    "@timestamp": "2023-09-28T08:45:25.072563Z",
    "@version": "1",
    "message": "Storing 3 new uris for https://www.bbc.co.uk",
    "logger_name": "ophan.google.indexing.observatory.DataStore",
    "thread_name": "scala-execution-context-global-24",
    "level": "INFO",
    "level_value": 20000,
    "site": "https://www.bbc.co.uk",
    "site.sitemap.uris.all": 1300,
    "site.sitemap.uris.old": 1297,
    "site.sitemap.uris.new": 3,
    "buildNumber": "99",
    "gitCommitId": "3b8cce0e1a470f2f08ee7392ceda8f0db2c36b00",
    "uniqueIdForVM": "e29cf5f5-caa3-4787-a803-b8b3dba58629"
}

```

...but when that was being picked up by https://github.com/guardian/cloudwatch-logs-management and sent to the ELK, the log context data was being rejected as bad.

In the ELK, the dot-nesting we make for context fields actually defines a real Elasticsearch document structure, and in that structure, a particular path can be either a single value, or a containing object, but not both. The ELK works out which from the values we give it- but sometimes those implications contradict each other:

```
"site" -> sitemapDownload.site.url
```
...means `site` is a string value, but:
```
"site.sitemap.uris.old" -> alreadyKnownUris.size
```
 ...means `site` is an _object_ that contains other values. **This is a 'mapping conflict'**, and [the whole log line gets dropped](https://discuss.elastic.co/t/tried-to-parse-field-as-object-but-found-a-concrete-value/229134).

This is a similar issue to https://github.com/guardian/ophan/pull/3254 seen in the past. It would be cool if the logging code within the lambda itself could identify issues like this and warn about them!


# Fix

We can't nest the `sitemap.uris.*` fields within site - because we've already declared it's not an object - so we just de-nest them from `site`. Thanks to @paulmr  for talking this through with me!