### PR TITLE
Add redirect-resolving code - but don't use it yet

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,10 @@ libraryDependencies ++= Seq(
   "org.typelevel" %% "cats-core" % catsVersion,
   "org.typelevel" %% "alleycats-core" % catsVersion,
 
-  "com.bnsal" % "sitemap-parser" % "1.0.3"
+  "com.bnsal" % "sitemap-parser" % "1.0.3",
+  "org.typelevel" %% "literally" % "1.1.0" % Test,
+
+  "com.github.blemale" %% "scaffeine" % "5.2.1"
 
 ) ++ Seq("ssm", "url-connection-client").map(artifact => "software.amazon.awssdk" % artifact % "2.20.150")
 

--- a/src/main/scala/ophan/google/indexing/observatory/DataStore.scala
+++ b/src/main/scala/ophan/google/indexing/observatory/DataStore.scala
@@ -1,12 +1,12 @@
 package ophan.google.indexing.observatory
 
-import DataStore.{scanamoAsync, table}
+import ophan.google.indexing.observatory.DataStore.{scanamoAsync, table}
+import ophan.google.indexing.observatory.Resolution.Resolved
 import ophan.google.indexing.observatory.logging.Logging
-import ophan.google.indexing.observatory.model.AvailabilityRecord._
+import ophan.google.indexing.observatory.model.AvailabilityRecord.*
 import ophan.google.indexing.observatory.model.{AvailabilityRecord, CheckReport}
-import org.scanamo._
-import org.scanamo.syntax._
-import org.scanamo.update.UpdateExpression
+import org.scanamo.*
+import org.scanamo.syntax.*
 
 import java.net.URI
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -21,24 +21,29 @@ object DataStore {
 }
 
 case class DataStore() extends Logging {
-  def fetchExistingRecordsFor(uris: Set[URI]): Future[Map[URI,AvailabilityRecord]] = scanamoAsync.exec(
+  def fetchExistingRecordsFor(uris: Set[URI]): Future[Set[AvailabilityRecord]] = scanamoAsync.exec(
     table.getAll(Field.Uri in uris)
-  ).map(_.flatMap(_.toOption).map(record => record.uri -> record).toMap)
+  ).map(_.flatMap(_.toOption))
 
-  def storeNewRecordsFor(sitemapDownload: SitemapDownload, alreadyKnownUris: Set[URI]): Future[Unit] = {
-    val urisNotSeenBefore = sitemapDownload.allUris -- alreadyKnownUris
+
+  /**
+   * When we initially store an availability record in the DynamoDB table, we don't store anything about its
+   * availability, just its URL, whether it redirects, and the time we first have seen this url.
+   */
+  def storeNewRecordsFor(sitemapDownload: SitemapDownload, urisNotSeenBefore: Set[URI]): Future[Unit] = {
     if (urisNotSeenBefore.isEmpty) Future.successful(()) else {
       logger.info(Map(
         "site" -> sitemapDownload.site.url,
         "sitemap.uris.all" -> sitemapDownload.allUris.size,
-        "sitemap.uris.old" -> alreadyKnownUris.size,
-        "sitemap.uris.new" -> urisNotSeenBefore.size
-      ), s"Storing ${urisNotSeenBefore.size} new uris for ${sitemapDownload.site.url}. Sample: ${urisNotSeenBefore.take(2).mkString(",")}")
+      ) ++ contextSampleOf("sitemap.uris.urisNotSeenBefore", urisNotSeenBefore),
+        s"Storing new uris for ${sitemapDownload.site.url}")
       scanamoAsync.exec(
-        table.putAll(urisNotSeenBefore.map(uri => AvailabilityRecord(uri, sitemapDownload.timestamp)))
+        table.putAll(urisNotSeenBefore.map { uri =>
+          val skippedResolution: Resolved = Resolution.Resolved(RedirectPath(Seq(uri)), false)
+          AvailabilityRecord(skippedResolution, sitemapDownload.timestamp)
+        })
       )
     }
-
   }
 
   def update(uri: URI, checkReport: CheckReport): Future[Option[AvailabilityRecord]] = {

--- a/src/main/scala/ophan/google/indexing/observatory/RedirectResolver.scala
+++ b/src/main/scala/ophan/google/indexing/observatory/RedirectResolver.scala
@@ -1,0 +1,126 @@
+package ophan.google.indexing.observatory
+
+import com.github.blemale.scaffeine.{AsyncLoadingCache, Scaffeine}
+import ophan.google.indexing.observatory.Resolution.{Resolved, Unresolved}
+import ophan.google.indexing.observatory.logging.Logging
+
+import java.net.URI
+import java.net.http.*
+import java.net.http.HttpClient.Redirect
+import java.net.http.HttpRequest.BodyPublishers
+import java.net.http.HttpRequest.BodyPublishers.noBody
+import java.net.http.HttpResponse.BodyHandlers
+import java.time.Duration
+import java.time.Duration.ofSeconds
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.concurrent.duration.*
+import scala.jdk.FutureConverters.*
+import scala.jdk.OptionConverters.*
+import scala.util.Try
+
+case class RedirectPath(locations: Seq[URI]) {
+  val originalUri: URI = locations.head
+  val numRedirects: Int = locations.size - 1
+  val doesRedirect: Boolean = numRedirects > 0
+
+  val isLoop: Boolean = locations.dropRight(1).contains(locations.last)
+
+  def adding(location: URI): RedirectPath = copy(locations :+ location)
+}
+
+enum Resolution {
+  val redirectPath: RedirectPath
+
+  case Resolved(redirectPath: RedirectPath, ok: Boolean)
+  case Unresolved(redirectPath: RedirectPath)
+}
+
+type Resp = Either[Boolean,URI]
+
+trait RedirectFollower {
+  /**
+   * Possible results:
+   * * HTTP 200
+   *
+   *
+   * Failure:
+   * * Domain does not exist - www.doesnotexist123123.com
+   * * Page is 404 - https://www.theguardian.com/uk/roberto-is-so-cool
+   * * Some kind of transient network connection failure
+   *
+   * @return Future(Left(bool)) if the url did not redirect elsewhere - `true` if we got a HTTP 200 response
+   */
+  def follow(uri: URI): Future[Resp]
+}
+
+
+
+object RedirectFollower extends RedirectFollower with Logging {
+
+  val HTTPRedirectStatusCodes: Set[Int] = Set(301, 302, 303, 307, 308)
+
+  def redirectGivenBy(requestUri: URI, response: HttpResponse[_]): Option[URI] =
+    if (HTTPRedirectStatusCodes.contains(response.statusCode)) getRedirectedURI(requestUri, response.headers) else None
+
+  // based on https://github.com/openjdk/jdk17/blob/4afbcaf55/src/java.net.http/share/classes/jdk/internal/net/http/RedirectFilter.java#L132
+  private def getRedirectedURI(requestUri: URI, headers: HttpHeaders): Option[URI] =
+    headers.location.flatMap { newLocation =>
+      Try(URI.create(newLocation)).toOption
+    }.map(requestUri.resolve) // redirect could be relative to original URL
+
+
+  extension (headers: HttpHeaders) def location: Option[String] = headers.firstValue("Location").toScala
+
+  private val httpClient: HttpClient = HttpClient.newBuilder()
+    .followRedirects(Redirect.NEVER)
+    .connectTimeout(ofSeconds(2))
+    .build()
+
+  def requestFor(uri: URI): HttpRequest =
+    HttpRequest.newBuilder().uri(uri).timeout(ofSeconds(2))
+      .header("User-Agent", "curl/7.54") // NYT accepts curl, but rejects the default "Java-http-client" User-Agent!
+      .method("HEAD", noBody()).build()
+
+
+  def follow(uri: URI): Future[Resp] = httpClient.sendAsync(requestFor(uri), BodyHandlers.discarding()).asScala.map {
+    response => redirectGivenBy(uri, response).toRight {
+      val statusCode = response.statusCode
+      val responseOk = statusCode == 200
+      if (!responseOk) {
+        logger.warn(Map(
+          "redirect.resolution.uri" -> uri.toString,
+          "redirect.resolution.statusCode" -> statusCode
+        ), s"Bad status code $statusCode (not a redirect!) while trying to resolve '$uri'")
+      }
+      responseOk
+    }
+  }.recover { exception =>
+    logger.warn(Map(
+      "redirect.resolution.uri" -> uri.toString
+    ), s"Exception while trying to resolve '$uri'", exception)
+    Left(false)
+  }
+}
+
+class RedirectResolver(redirectFollower: RedirectFollower, val maxRedirects: Int = 5) {
+
+  private val cache: AsyncLoadingCache[URI, Resp] =
+    Scaffeine()
+      .recordStats()
+      .expireAfterWrite(5.minutes)
+      .maximumSize(100000)
+      .buildAsyncFuture(redirectFollower.follow)
+
+  def resolve(uri: URI): Future[Resolution] = resolve(RedirectPath(Seq(uri)))
+
+  def resolve(redirectPath: RedirectPath): Future[Resolution] =
+    if (redirectPath.numRedirects >= maxRedirects || redirectPath.isLoop) Future.successful(Unresolved(redirectPath))
+    else cache.get(redirectPath.locations.last).flatMap {
+      resp => resp.fold(
+        ok => Future.successful(Resolved(redirectPath, ok)),
+        redirectUri => resolve(redirectPath.adding(redirectUri))
+      )
+    }
+
+}

--- a/src/main/scala/ophan/google/indexing/observatory/SitemapDownloader.scala
+++ b/src/main/scala/ophan/google/indexing/observatory/SitemapDownloader.scala
@@ -3,6 +3,7 @@ package ophan.google.indexing.observatory
 import ophan.google.indexing.observatory.logging.Logging
 import ophan.google.indexing.observatory.model.Site
 
+import java.io.ByteArrayInputStream
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpClient.Redirect
@@ -12,7 +13,7 @@ import java.net.http.HttpResponse.BodyHandlers
 import java.time.Duration.ofSeconds
 import java.time.Instant
 import scala.concurrent.{ExecutionContext, Future}
-import scala.jdk.FutureConverters._
+import scala.jdk.FutureConverters.*
 
 case class SitemapDownload(site: Site, timestamp: Instant, allUris: Set[URI])
 
@@ -25,13 +26,13 @@ class SitemapDownloader(implicit
   def fetchSitemapEntriesFor(site: Site): Future[SitemapDownload] = {
     val start = Instant.now()
     Future.traverse(site.sitemaps) { sitemapUrl =>
-      client.sendAsync(HttpRequest.newBuilder(sitemapUrl).GET().build(), BodyHandlers.ofInputStream()).asScala.map { response =>
+      client.sendAsync(HttpRequest.newBuilder(sitemapUrl).GET().build(), BodyHandlers.ofString()).asScala.map { response =>
         logger.info(Map(
           "site" -> site.url,
           "sitemap.url" -> sitemapUrl,
           "sitemap.response.statusCode" -> response.statusCode()
         ), s"Received HTTP ${response.statusCode()} response for $sitemapUrl sitemap")
-        val uris: Set[URI] = SitemapParser.parse(response.body, site.url)
+        val uris: Set[URI] = SitemapParser.parse(new ByteArrayInputStream(response.body.getBytes()), site.url)
         logger.info(Map(
           "site" -> site.url,
           "sitemap.url" -> sitemapUrl,

--- a/src/main/scala/ophan/google/indexing/observatory/logging/Logging.scala
+++ b/src/main/scala/ophan/google/indexing/observatory/logging/Logging.scala
@@ -4,7 +4,8 @@ import net.logstash.logback.marker.LogstashMarker
 import net.logstash.logback.marker.Markers.appendEntries
 import org.slf4j.{Logger, LoggerFactory}
 
-import scala.jdk.CollectionConverters._
+import java.net.URI
+import scala.jdk.CollectionConverters.*
 import scala.language.implicitConversions
 
 trait Logging {
@@ -13,4 +14,9 @@ trait Logging {
 
   implicit def mapToContext(c: Map[String, _]): LogstashMarker = appendEntries(c.asJava)
 
+  def contextSampleOf(prefix: String, coll: Iterable[URI]): Map[String, _] = Map(
+    s"$prefix.count" -> coll.size,
+    s"$prefix.sample" -> coll.take(3).asJava
+  )
+  
 }

--- a/src/main/scala/ophan/google/indexing/observatory/model/AvailabilityRecord.scala
+++ b/src/main/scala/ophan/google/indexing/observatory/model/AvailabilityRecord.scala
@@ -1,5 +1,6 @@
 package ophan.google.indexing.observatory.model
 
+import ophan.google.indexing.observatory.Resolution
 import ophan.google.indexing.observatory.model.AvailabilityRecord.Field.FirstSeenInSitemapDateIndexKey
 import ophan.google.indexing.observatory.model.AvailabilityRecord.{DelayForFirstCheckAfterContentIsFirstSeenInSitemap, reasonableTimeBetweenChecksForContentAged}
 
@@ -17,12 +18,24 @@ import scala.math.Ordering.Implicits.*
 
 case class CheckStatus(timestamp: Instant, wasFound: Boolean)
 
+// Resolved URI? Was page HTTP 200 OK?
+// Want to know if we should:
+// a) ignore this page, as it was not OK - 404 or redirected too much
+// b) scan an alternate url - a page which we were redirected to, which was ok
+// c) scan darn url.
+
+// pageResolvedOk
+// uriAfterRedirects
 case class AvailabilityRecord(
   uri: URI,
+  finalUriAfterRedirects: Option[URI],
+  uriResolvedOk: Boolean,
   firstSeenInSitemap: Instant,
   missing: Option[Instant] = None,
   found: Option[Instant] = None
 ) {
+  val ultimateUri: URI = finalUriAfterRedirects.getOrElse(uri)
+  
   val latestCheck: Option[CheckStatus] = (
     missing.map(CheckStatus(_, wasFound = false)) ++ found.map(CheckStatus(_, wasFound = true))
   ).toSeq.maxByOption(_.timestamp)
@@ -30,18 +43,23 @@ case class AvailabilityRecord(
   val contentHasBeenFound: Boolean = latestCheck.exists(_.wasFound)
   val currentlyRecordedMissing: Boolean = latestCheck.exists(!_.wasFound)
 
-  def needsCheckingNow()(implicit clock: Clock = Clock.systemUTC): Boolean = {
-    !contentHasBeenFound && {
-      val now = clock.instant()
-      val timeSinceFirstSeenInSitemap = Duration.between(firstSeenInSitemap, now)
-      timeSinceFirstSeenInSitemap > DelayForFirstCheckAfterContentIsFirstSeenInSitemap && missing.forall { m =>
-        Duration.between(m, now) > reasonableTimeBetweenChecksForContentAged(timeSinceFirstSeenInSitemap)
-      }
+  def needsCheckingNow()(implicit clock: Clock = Clock.systemUTC): Boolean = !contentHasBeenFound && {
+    val now = clock.instant()
+    val timeSinceFirstSeenInSitemap = Duration.between(firstSeenInSitemap, now)
+    timeSinceFirstSeenInSitemap > DelayForFirstCheckAfterContentIsFirstSeenInSitemap && missing.forall { m =>
+      Duration.between(m, now) > reasonableTimeBetweenChecksForContentAged(timeSinceFirstSeenInSitemap)
     }
   }
 }
 
 object AvailabilityRecord {
+
+  def apply(resolved: Resolution.Resolved, firstSeenInSitemap: Instant): AvailabilityRecord = AvailabilityRecord(
+    uri = resolved.redirectPath.locations.head,
+    uriResolvedOk = resolved.ok,
+    finalUriAfterRedirects = resolved.redirectPath.locations.tail.lastOption,
+    firstSeenInSitemap = firstSeenInSitemap
+  )
   
   implicit val uriAsStringFormat: DynamoFormat[URI] =
     DynamoFormat.coercedXmap[URI, String, URISyntaxException](new URI(_), _.toString)

--- a/src/main/scala/ophan/google/indexing/observatory/model/Site.scala
+++ b/src/main/scala/ophan/google/indexing/observatory/model/Site.scala
@@ -8,7 +8,7 @@ object Sites {
   val NewYorkTimes = Site(
     url="https://www.nytimes.com/",
     searchEngineId="70f791f05cbda4a5c",
-    sitemaps=Set(new URI("https://www.nytimes.com/sitemaps/new/news-1.xml.gz"))
+    sitemaps=Set(new URI("https://www.nytimes.com/sitemaps/new/news.xml.gz"))
   )
 
 // The Independent appear to change/evolve their URLs often, leaving them in the sitemap with

--- a/src/test/scala/ophan/google/indexing/observatory/RedirectResolverTest.scala
+++ b/src/test/scala/ophan/google/indexing/observatory/RedirectResolverTest.scala
@@ -1,0 +1,87 @@
+package ophan.google.indexing.observatory
+
+import ophan.google.indexing.observatory.Resolution.Resolved
+import ophan.google.indexing.observatory.literals.*
+import org.scalatest.Inside
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.net.URI
+import scala.concurrent.Future
+
+class RedirectResolverTest extends AnyFlatSpec with Matchers with ScalaFutures with IntegrationPatience with Inside {
+  def resolving[U](uri: URI)(fun: Resolution => U)(using r: RedirectResolver) = whenReady(r.resolve(uri))(fun)
+
+  {
+    given liveResolver: RedirectResolver = RedirectResolver(RedirectFollower)
+
+    it should "resolve a NYT url - note the NYT seem to accept curl but not other User-Agents!" in {
+      resolving(uri"https://www.nytimes.com/2023/10/03/sports/cricket/cricket-world-cup-explained.html") {
+        inside(_) {
+          case resolved: Resolved => resolved.ok shouldBe true
+        }
+      }
+    }
+
+    it should "resolve a Daily Mail url" in {
+      resolving(uri"https://www.dailymail.co.uk/news/article-12589205/Well-supporting-Ukraine-Biden-tells-allies-President-calls-global-partners-assure-U-S-giving-Zelensky-cash-despite-chaos-Congress-pro-Kremlin-candidate-storming-power-Slovakia.html") {
+        inside(_) {
+          case resolved: Resolved => resolved.ok shouldBe true
+        }
+      }
+    }
+
+    it should "follow a BBC 'av' page" in {
+      resolving(uri"https://www.bbc.co.uk/sport/av/football/66930004") {
+         inside(_) {
+           case resolved: Resolved => resolved.ok shouldBe true
+         }
+      }
+    }
+
+    it should "follow a BBC url which redirects to an 'av' page" in {
+      val expectedRedirects = Seq(
+        uri"https://www.bbc.co.uk/news/uk-politics-63534039",
+        uri"https://www.bbc.co.uk/news/av/uk-politics-63534039"
+      )
+
+      resolving(expectedRedirects.head) {
+        _ shouldBe Resolved(RedirectPath(expectedRedirects), ok = true)
+      }
+    }
+
+    it should "not crash for domains that do not exist" in {
+      val uriWithNonExistentDomain = uri"https://www.doesnotexist12312312234523532534546.com/"
+
+      resolving(uriWithNonExistentDomain) {
+        _ shouldBe Resolved(RedirectPath(Seq(uriWithNonExistentDomain)), ok = false)
+      }
+    }
+
+    it should "not crash for paths that do not exist" in {
+      val uriWithNonExistentPath = uri"https://www.theguardian.com/uk/roberto-is-the-coolest"
+
+      resolving(uriWithNonExistentPath) {
+        _ shouldBe Resolved(RedirectPath(Seq(uriWithNonExistentPath)), ok = false)
+      }
+    }
+  }
+
+  it should "not follow infinite redirects" in {
+    val redirectForeverToNewUrls = redirectPathForTesting(_.toIntOption.fold(0)(_ + 1).toString)
+    given resolver: RedirectResolver = RedirectResolver(redirectForeverToNewUrls, maxRedirects = 20)
+
+    resolving(uri"https://example.com/foo") { _.redirectPath.numRedirects shouldBe resolver.maxRedirects }
+  }
+
+  it should "detect a loop" in {
+    val redirectInLoop = redirectPathForTesting(_.toIntOption.fold(0)(pathNum => (pathNum + 1) % 6).toString)
+    given RedirectResolver = RedirectResolver(redirectInLoop, maxRedirects = 20)
+
+    resolving(uri"https://example.com/0") { _.redirectPath.numRedirects shouldBe 6 }
+  }
+
+  def redirectPathForTesting(pathChanger: String => String): RedirectFollower = (uri: URI) =>
+    Future.successful(Right(new URI(uri.getScheme, uri.getHost, "/" + pathChanger(uri.getPath.stripPrefix("/")), uri.getFragment)))
+}

--- a/src/test/scala/ophan/google/indexing/observatory/literals.scala
+++ b/src/test/scala/ophan/google/indexing/observatory/literals.scala
@@ -1,0 +1,14 @@
+package ophan.google.indexing.observatory
+
+import org.typelevel.literally.Literally
+
+import java.net.URI
+import scala.util.Try
+
+object literals:
+  extension (inline ctx: StringContext)
+    inline def uri(inline args: Any*): URI = ${URILiteral('ctx, 'args)}
+
+  object URILiteral extends Literally[URI]:
+    def validate(s: String)(using Quotes) =
+      Try(URI.create(s)).toEither.left.map(_.getMessage).map(_ => '{URI.create(${Expr(s)})})

--- a/src/test/scala/ophan/google/indexing/observatory/model/AvailabilityRecordTest.scala
+++ b/src/test/scala/ophan/google/indexing/observatory/model/AvailabilityRecordTest.scala
@@ -1,11 +1,15 @@
 package ophan.google.indexing.observatory.model
 
+import ophan.google.indexing.observatory.{RedirectPath, Resolution}
+import ophan.google.indexing.observatory.literals.uri
 import ophan.google.indexing.observatory.model.AvailabilityRecord.Field.FirstSeenInSitemapDateIndexKey
 import ophan.google.indexing.observatory.model.AvailabilityRecord.{DelayForFirstCheckAfterContentIsFirstSeenInSitemap, reasonableTimeBetweenChecksForContentAged}
 import org.scalatest.OptionValues
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scanamo.{DynamoObject, DynamoValue}
+import ophan.google.indexing.observatory.Resolution.Resolved
 
 import java.net.URI
 import java.time.{Duration, Instant}
@@ -13,7 +17,7 @@ import java.time.Duration.{ofHours, ofMinutes, ofSeconds}
 import java.time.temporal.ChronoUnit.SECONDS
 import scala.math.Ordering.Implicits.*
 
-class AvailabilityRecordTest extends AnyFlatSpec with Matchers with OptionValues {
+class AvailabilityRecordTest extends AnyFlatSpec with Matchers with OptionValues  with ScalaFutures with IntegrationPatience {
 
   val elapsedTimeAtEachCheck: LazyList[Duration] = LazyList.iterate(DelayForFirstCheckAfterContentIsFirstSeenInSitemap) { accumulatedTime =>
     accumulatedTime.plus(reasonableTimeBetweenChecksForContentAged(accumulatedTime))
@@ -44,16 +48,33 @@ class AvailabilityRecordTest extends AnyFlatSpec with Matchers with OptionValues
 
   it should "serialise to Dynamo" in {
     val ar = AvailabilityRecord(
-      uri = new URI("https://www.theguardian.com/foo"),
+      uri = uri"https://www.theguardian.com/foo",
+      finalUriAfterRedirects = Some(uri"https://www.theguardian.com/bar"),
+      uriResolvedOk = true,
       firstSeenInSitemap = Instant.parse("2022-11-02T16:41:37Z"),
       missing = Some(Instant.parse("2022-12-05T20:10:34Z")),
       found = None
     )
     val obj: DynamoObject = AvailabilityRecord.formatAvailabilityRecord.write(ar).asObject.value
     obj("uri").value shouldBe DynamoValue.fromString("https://www.theguardian.com/foo")
+    obj("finalUriAfterRedirects").value shouldBe DynamoValue.fromString("https://www.theguardian.com/bar")
+    obj("uriResolvedOk").value shouldBe DynamoValue.fromBoolean(true)
     obj("firstSeenInSitemap").value shouldBe DynamoValue.fromString("2022-11-02T16:41:37Z")
     obj("missing").value shouldBe DynamoValue.fromString("2022-12-05T20:10:34Z")
     obj("found") shouldBe None
     obj(FirstSeenInSitemapDateIndexKey).value shouldBe DynamoValue.fromString("2022-11-02Z")
+  }
+
+  it should "Create an AvailabilityRecord instance and the finalUriAfterRedirects property is correct" in {
+    val resolved: Resolution.Resolved = Resolution.Resolved(RedirectPath(Seq(
+      uri"https://www.bbc.co.uk/news/uk-politics-63534039",
+      uri"https://www.bbc.co.uk/news/av/uk-politics-63534039"
+    )), ok = true)
+
+    val availabilityRecord: AvailabilityRecord = AvailabilityRecord(resolved, Instant.parse("2022-12-05T20:10:34Z"))
+
+    availabilityRecord.uri shouldBe uri"https://www.bbc.co.uk/news/uk-politics-63534039"
+    availabilityRecord.finalUriAfterRedirects.value shouldBe uri"https://www.bbc.co.uk/news/av/uk-politics-63534039"
+    availabilityRecord.ultimateUri shouldBe uri"https://www.bbc.co.uk/news/av/uk-politics-63534039"
   }
 }


### PR DESCRIPTION
Reattempt after https://github.com/guardian/google-search-indexing-observatory/pull/12 gave us `IOException("too many concurrent streams")`, and had to be reverted with https://github.com/guardian/google-search-indexing-observatory/pull/36... this reinstates most of the redirect resolving code, but doesn't use it in earnest - first, we just want to check if we can do _any_ redirect_ resolving at all.

The BBC have share location urls in their sitemap which redirect, eg:

https://www.bbc.co.uk/news/uk-politics-63534039 - in sitemap https://www.bbc.co.uk/news/av/uk-politics-63534039 - ultimate url

...it's only the ultimate url (with '/av', in this case) that can be found in Google Search results.

Updated process
---------------

Resolution of new urls only occurs when the url is first found in the sitemap (we don't want to have to repeatedly resolve the same urls over and over again) - this redirected url is stored in the new `finalUriAfterRedirects` column.

Urls are never searched for in Google Search when we first see them in the sitemap - we wait until we have had a new lambda run, and the url has been loaded as an existing `AvailabilityRecord` in dynamodb. It's at that point that we search for the redirected url, which we recorded earlier.

Which url to use when?
----------------------

* original url : needed as the primary key, because the observatory lambda uses it to lookup every entry from the sitemap (we don't want to have to resolve every url from the sitemap every time we load the sitemap)
* redirected url : when we search google for the content, we need to be using the redirected url when we're checking for matches.

Added logging of bad HTTP-response status codes

As suggested by Sam!
