### PR TITLE
Use OkHttp library for concurrent url resolving

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,7 @@ libraryDependencies ++= Seq(
   "org.slf4j" % "log4j-over-slf4j" % "2.0.9", //  log4j-over-slf4j provides `org.apache.log4j.MDC`, which is dynamically loaded by the Lambda runtime
   "ch.qos.logback" % "logback-classic" % "1.4.11",
   "com.lihaoyi" %% "upickle" % "3.1.3",
+  "com.squareup.okhttp3" % "okhttp" % "4.10.0",
 
   "com.madgag" %% "scala-collection-plus" % "0.11",
   "com.google.http-client" % "google-http-client-gson" % "1.43.3",

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
 ) ++ Seq("ssm", "url-connection-client").map(artifact => "software.amazon.awssdk" % artifact % "2.20.150")
 
 Test / testOptions +=
-  Tests.Argument(TestFrameworks.ScalaTest, "-u", s"test-results/scala-${scalaVersion.value}")
+  Tests.Argument(TestFrameworks.ScalaTest, "-u", s"test-results/scala-${scalaVersion.value}", "-o")
 
 enablePlugins(RiffRaffArtifact, BuildInfoPlugin)
 

--- a/src/main/scala/ophan/google/indexing/observatory/AvailabilityUpdaterService.scala
+++ b/src/main/scala/ophan/google/indexing/observatory/AvailabilityUpdaterService.scala
@@ -37,9 +37,7 @@ case class AvailabilityUpdaterService(
     val urisNotSeenBefore = sitemapDownload.allUris -- excludingAlreadyExistingRecords.map(_.uri)
     for {
       redirectResolutionsForUrisNotSeenBefore <- Future.traverse(urisNotSeenBefore)(redirectResolver.resolve)
-      _ <- dataStore.storeNewRecordsFor(sitemapDownload, redirectResolutionsForUrisNotSeenBefore.collect {
-        case r: Resolved => r
-      })
+      _ <- dataStore.storeNewRecordsFor(sitemapDownload, redirectResolutionsForUrisNotSeenBefore)
     } yield ()
   }
 

--- a/src/main/scala/ophan/google/indexing/observatory/DataStore.scala
+++ b/src/main/scala/ophan/google/indexing/observatory/DataStore.scala
@@ -1,7 +1,7 @@
 package ophan.google.indexing.observatory
 
 import ophan.google.indexing.observatory.DataStore.{scanamoAsync, table}
-import ophan.google.indexing.observatory.Resolution.Resolved
+import ophan.google.indexing.observatory.Resolution.{Resolved, Unresolved}
 import ophan.google.indexing.observatory.logging.Logging
 import ophan.google.indexing.observatory.model.AvailabilityRecord.*
 import ophan.google.indexing.observatory.model.{AvailabilityRecord, CheckReport}
@@ -30,18 +30,23 @@ case class DataStore() extends Logging {
    * When we initially store an availability record in the DynamoDB table, we don't store anything about its
    * availability, just its URL, whether it redirects, and the time we first have seen this url.
    */
-  def storeNewRecordsFor(sitemapDownload: SitemapDownload, resolutionOfNewUris: Set[Resolution.Resolved]): Future[Unit] = {
-    if (resolutionOfNewUris.isEmpty) Future.successful(()) else {
-      val redirectingUrls = resolutionOfNewUris.filter(_.redirectPath.doesRedirect)
-      logger.info(Map(
-        "site" -> sitemapDownload.site.url,
-        "sitemap.uris.all" -> sitemapDownload.allUris.size,
-      ) ++ contextSampleOf("sitemap.uris.new.resolved", resolutionOfNewUris.map(_.redirectPath.originalUri))
-        ++ contextSampleOf("sitemap.uris.new.resolved.notOK", resolutionOfNewUris.filter(!_.ok).map(_.redirectPath.originalUri))
-        ++ contextSampleOf("sitemap.uris.new.redirecting", redirectingUrls.map(_.redirectPath.originalUri)),
-        s"Storing new uris for ${sitemapDownload.site.url}")
+  def storeNewRecordsFor(sitemapDownload: SitemapDownload, resolutionsForUrisNotSeenBefore: Set[Resolution]): Future[Unit] = {
+    def logContextFor[R <: Resolution](fieldSuffix: String, resolutions: Set[R]): Map[String, _] =
+      contextSampleOf(s"sitemap.uris.fresh.$fieldSuffix", resolutions.map(_.redirectPath.originalUri))
+
+    val resolvedNewUris = resolutionsForUrisNotSeenBefore.collect { case r: Resolved => r }
+    logger.info(Map(
+      "site" -> sitemapDownload.site.url,
+      "sitemap.uris.all" -> sitemapDownload.allUris.size,
+    ) ++ logContextFor("unresolved", resolutionsForUrisNotSeenBefore.collect { case u: Unresolved => u})
+      ++ logContextFor("resolved", resolvedNewUris)
+      ++ logContextFor("resolved.notOK", resolvedNewUris.filter(!_.ok))
+      ++ logContextFor("resolved.redirecting", resolvedNewUris.filter(_.redirectPath.doesRedirect)),
+      s"Storing ${resolvedNewUris.size} new resolved uris for ${sitemapDownload.site.url}")
+
+    if (resolvedNewUris.isEmpty) Future.successful(()) else {
       scanamoAsync.exec(
-        table.putAll(resolutionOfNewUris.map { resolved => AvailabilityRecord(resolved, sitemapDownload.timestamp) })
+        table.putAll(resolvedNewUris.map { resolved => AvailabilityRecord(resolved, sitemapDownload.timestamp) })
       )
     }
   }

--- a/src/main/scala/ophan/google/indexing/observatory/Lambda.scala
+++ b/src/main/scala/ophan/google/indexing/observatory/Lambda.scala
@@ -65,14 +65,6 @@ object Lambda extends Logging {
 
     Await.result(eventual, 40.seconds)
     println("Everything complete")
-
-    Await.ready({
-      val eventualResolution = redirectResolver.resolve(URI.create("https://www.bbc.co.uk/news/uk-politics-63534039"))
-      eventualResolution.foreach { resolution =>
-        logger.info(s"BBC url resolved to $resolution")
-      }
-      eventualResolution
-    }, 10.seconds)
   }
 
   /*

--- a/src/main/scala/ophan/google/indexing/observatory/RedirectResolver.scala
+++ b/src/main/scala/ophan/google/indexing/observatory/RedirectResolver.scala
@@ -6,7 +6,6 @@ import ophan.google.indexing.observatory.Resolution.{Resolved, Unresolved}
 import ophan.google.indexing.observatory.logging.Logging
 
 import java.net.URI
-import java.net.http.*
 import java.time.Duration
 import java.time.Duration.ofSeconds
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -71,8 +70,7 @@ object RedirectFollower extends RedirectFollower with Logging {
     new OkHttpClient.Builder()
       .followRedirects(false)
       .followSslRedirects(false)
-      .callTimeout(Duration.ofSeconds(2))
-      .readTimeout(Duration.ofSeconds(2))
+      .callTimeout(Duration.ofSeconds(5))
       .build()
 
   def requestFor(uri: URI): Request =

--- a/src/main/scala/ophan/google/indexing/observatory/model/Site.scala
+++ b/src/main/scala/ophan/google/indexing/observatory/model/Site.scala
@@ -22,7 +22,7 @@ object Sites {
   )
 
   val BBC = Site(
-    url = "https://www.bbc.co.uk",
+    url = "https://www.bbc.co.uk/",
     searchEngineId = "b44c6a8d0e79b43bb",
     sitemaps = Set(
       new URI("https://www.bbc.co.uk/sitemaps/https-sitemap-uk-news-1.xml"),
@@ -31,7 +31,7 @@ object Sites {
   )
 
   val DailyMail= Site(
-    url = "https://www.dailymail.co.uk",
+    url = "https://www.dailymail.co.uk/",
     searchEngineId = "e42e842597f034061",
     sitemaps = Set(new URI("https://www.dailymail.co.uk/google-news-sitemap1.xml"))
   )


### PR DESCRIPTION
We saw a lot of `IOException("too many concurrent streams")` errors in the AWS Lambda from PR https://github.com/guardian/google-search-indexing-observatory/pull/12 where we were using the `java.net.http HTTPClient` (added in Java 11) for resolving lots of urls at once - we had to revert it. According to [one answer on stackoverflow](https://stackoverflow.com/a/57359328/438886), the OkHTTP library behaves better:

> "Finally, I ended up by using OkHttp. It handles the problem (it just waits until some streams are freed up if the number of concurrent streams reaches max_concurrent_streams)."

This PR follows on from https://github.com/guardian/google-search-indexing-observatory/pull/37, which committed most of the redirect-resolving code, but deliberately omitted _calling_ the redirecting code, as it was throwing those `IOException`s.

We've verified over the past 2 days (Wednesday 4th-Friday 6th October) with a [test deploy](https://riffraff.gutools.co.uk/deployment/view/4250b546-7034-40eb-83a7-c7e6e0694a1f) that there are [no exceptions being thrown](https://logs.gutools.co.uk/s/ophan/goto/3dd0cf00-6450-11ee-bdfd-cb86db0ad0a5) on the AWS Lambda when we use OkHttp rather than Java 11's `java.net.http HTTPClient` (as used in commit 6e1f88ef022150dd50414440e7ffa84cc5ac8b55):

![image](https://github.com/guardian/google-search-indexing-observatory/assets/52038/3e7542e9-86ec-408f-9ae6-6d6ceea394e6)
