### PR TITLE
Deprecate Custom Search Site Restricted JSON API

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,18 @@ and collating observations of distant sites and processes that are visible to us
 ## Steps performed by the Observatory
 
 1. Fetch the Sitemap XML for a news site
-2. Hit the [Google Custom Search Site Restricted JSON API](https://developers.google.com/custom-search/v1/site_restricted_api)
+2. Hit the [Discovery Engine API (service is named Google Vertex Agent Builder)](https://cloud.google.com/generative-ai-app-builder/docs/reference/rest)
    to check if the content listed is available in Google search.
-   [API Consumption](https://console.cloud.google.com/apis/api/customsearch.googleapis.com/metrics?project=ophan-reborn-2017) &
+   [API Consumption](https://console.cloud.google.com/gen-app-builder/monitoring?inv=1&invt=AbigZA&project=ophan-reborn-2017) &
    [Cost 💰💰💰](https://console.cloud.google.com/apis/api/customsearch.googleapis.com/cost?project=ophan-reborn-2017)
    for this can be monitored in the Google Cloud console.
 3. Stores whether each article is available (or not) in an AWS DynamoDb table.
+
+## Vertex Agent Builder
+
+When setting up search functionality in the GCP Agent Builder, we need to create both an app and a dataStore in the Agent Builder for each website we want to search (in this case BBC, DailyMail, and NYT).
+While GCP's interface suggests this process creates a new search engine with its own database, this isn't actually what happens. Instead, it creates a filtered view of Google Search results, limited to the specific website URL we specify.
+_Note:_ Even though our code doesn't directly reference the App ID, you must still create both the app and the dataStore for each website - creating just the dataStore isn't sufficient and leads to API errors.
 
 ## Running the Checker locally
 

--- a/build.sbt
+++ b/build.sbt
@@ -27,8 +27,6 @@ libraryDependencies ++= Seq(
   "com.squareup.okhttp3" % "okhttp" % "4.12.0",
 
   "com.madgag" %% "scala-collection-plus" % "0.11",
-  "com.google.http-client" % "google-http-client-gson" % "1.44.1",
-  "com.google.apis" % "google-api-services-customsearch" % "v1-rev20240103-2.0.0",
   "org.scanamo" %% "scanamo" % "1.0.0-M30",
   "org.scalatest" %% "scalatest" % "3.2.18" % Test,
   "org.typelevel" %% "cats-core" % catsVersion,

--- a/src/main/scala/ophan/google/indexing/observatory/Credentials.scala
+++ b/src/main/scala/ophan/google/indexing/observatory/Credentials.scala
@@ -4,7 +4,7 @@ import ophan.google.indexing.observatory.logging.Logging
 
 case object Credentials extends Logging {
   def fetchKeyFromParameterStore(value: String): String = {
-    val paramName = s"/PROD/ophan/google-search-indexing-observatory/$value"
+    val paramName = s"/PROD/ophan/google-search-index-checker/$value"
     logger.info(Map(
       "credentials.paramName" -> paramName,
     ), s"Loading param: '$paramName'")

--- a/src/main/scala/ophan/google/indexing/observatory/GoogleSearchService.scala
+++ b/src/main/scala/ophan/google/indexing/observatory/GoogleSearchService.scala
@@ -28,7 +28,7 @@ object SearchResult {
   implicit val rw: ReadWriter[SearchResult] = macroRW
 }
 
-case class SearchResponse(results: List[SearchResult])
+case class SearchResponse(results: List[SearchResult] = List.empty)
 
 object SearchResponse {
   implicit val rw: ReadWriter[SearchResponse] = macroRW

--- a/src/main/scala/ophan/google/indexing/observatory/GoogleSearchService.scala
+++ b/src/main/scala/ophan/google/indexing/observatory/GoogleSearchService.scala
@@ -54,7 +54,6 @@ class GoogleSearchService(
       val request = HttpRequest.newBuilder()
         .uri(URI.create(s"$baseUrl?key=$apiKey"))
         .header("Content-Type", "application/json")
-        .header("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36")
         .POST(HttpRequest.BodyPublishers.ofString(requestBody.toString()))
         .build()
 

--- a/src/main/scala/ophan/google/indexing/observatory/Lambda.scala
+++ b/src/main/scala/ophan/google/indexing/observatory/Lambda.scala
@@ -33,8 +33,8 @@ object Lambda extends Logging {
   val sitemapDownloader = new SitemapDownloader()
 
   val googleSearchService: GoogleSearchService = {
-    val apiKey = fetchKeyFromParameterStore("Google/CustomSearch/ApiKey")
-    new GoogleSearchService(apiKey)
+    val apiKey = fetchKeyFromParameterStore("Google/VertexAISearch/ApiKeyNotEncrypted")
+    new GoogleSearchService(apiKey, "ophan-reborn-2017", "global")
   }
 
   val dataStore = new DataStore()

--- a/src/main/scala/ophan/google/indexing/observatory/model/Site.scala
+++ b/src/main/scala/ophan/google/indexing/observatory/model/Site.scala
@@ -2,12 +2,13 @@ package ophan.google.indexing.observatory.model
 
 import java.net.URI
 
-case class Site(url: String, searchEngineId: String, sitemaps: Set[URI])
+// Note, the datastore ID is only used but a connected app is still necessary for this to work
+case class Site(url: String, datastoreId: String, sitemaps: Set[URI])
 
 object Sites {
   val NewYorkTimes = Site(
     url="https://www.nytimes.com/",
-    searchEngineId="70f791f05cbda4a5c",
+    datastoreId="ophan-nytimes_1732116567495",
     sitemaps=Set(new URI("https://www.nytimes.com/sitemaps/new/news.xml.gz"))
   )
 
@@ -17,13 +18,13 @@ object Sites {
 // been redirected elsewhere.
   val Independent= Site(
     url = "https://www.independent.co.uk/",
-    searchEngineId = "119a788f858c94b0f",
+    datastoreId = "119a788f858c94b0f",
     sitemaps = Set(new URI("https://www.independent.co.uk/sitemaps/googlenews"))
   )
 
   val BBC = Site(
     url = "https://www.bbc.co.uk/",
-    searchEngineId = "b44c6a8d0e79b43bb",
+    datastoreId = "ophan-bbc-index_1731497852622",
     sitemaps = Set(
       new URI("https://www.bbc.co.uk/sitemaps/https-sitemap-uk-news-1.xml"),
       new URI("https://www.bbc.co.uk/sitemaps/https-sitemap-uk-news-2.xml")
@@ -32,25 +33,25 @@ object Sites {
 
   val DailyMail= Site(
     url = "https://www.dailymail.co.uk/",
-    searchEngineId = "e42e842597f034061",
+    datastoreId = "ophan-dailymail_1732116638977",
     sitemaps = Set(new URI("https://www.dailymail.co.uk/google-news-sitemap1.xml"))
   )
 
   val WashingtonPost = Site(
     url = "https://www.washingtonpost.com/",
-    searchEngineId = "65742b4f9808f4c04",
+    datastoreId = "65742b4f9808f4c04",
     sitemaps = Set(new URI("https://www.washingtonpost.com/arcio/news-sitemap/"))
   )
 
   val Telegraph = Site(
     url = "https://www.telegraph.co.uk/",
-    searchEngineId = "94687f1b5a1994152",
+    datastoreId = "94687f1b5a1994152",
     sitemaps = Set(new URI("https://www.telegraph.co.uk/sitemap-news.xml"))
   )
 
   val Sun = Site( // google-indexing-observatory-
     url = "https://www.thesun.co.uk/",
-    searchEngineId = "943ddaf5b540f41a3",
+    datastoreId = "943ddaf5b540f41a3",
     sitemaps = Set(new URI("https://www.thesun.co.uk/news-sitemap.xml"))
   )
 

--- a/src/main/scala/ophan/google/indexing/observatory/model/Site.scala
+++ b/src/main/scala/ophan/google/indexing/observatory/model/Site.scala
@@ -2,13 +2,22 @@ package ophan.google.indexing.observatory.model
 
 import java.net.URI
 
-case class Site(url: String, datastoreId: String, sitemaps: Set[URI])
+case class Site(
+                 url: String,
+                 datastoreId: String,
+                 sitemaps: Set[URI],
+               )
+
+sealed trait SearchStrategy
+case object UrlOnly extends SearchStrategy
+case object PathOnly extends SearchStrategy
+case object UrlAndQuotedPath extends SearchStrategy
 
 object Sites {
   val NewYorkTimes = Site(
     url="https://www.nytimes.com/",
     datastoreId="ophan-nytimes_1732116567495",
-    sitemaps=Set(new URI("https://www.nytimes.com/sitemaps/new/news.xml.gz"))
+    sitemaps=Set(new URI("https://www.nytimes.com/sitemaps/new/news.xml.gz")),
   )
 
 // The Independent appear to change/evolve their URLs often, leaving them in the sitemap with
@@ -18,7 +27,7 @@ object Sites {
   val Independent= Site(
     url = "https://www.independent.co.uk/",
     datastoreId = "119a788f858c94b0f",
-    sitemaps = Set(new URI("https://www.independent.co.uk/sitemaps/googlenews"))
+    sitemaps = Set(new URI("https://www.independent.co.uk/sitemaps/googlenews")),
   )
 
   val BBC = Site(
@@ -27,31 +36,31 @@ object Sites {
     sitemaps = Set(
       new URI("https://www.bbc.co.uk/sitemaps/https-sitemap-uk-news-1.xml"),
       new URI("https://www.bbc.co.uk/sitemaps/https-sitemap-uk-news-2.xml")
-    )
+    ),
   )
 
   val DailyMail= Site(
     url = "https://www.dailymail.co.uk/",
     datastoreId = "ophan-dailymail_1732116638977",
-    sitemaps = Set(new URI("https://www.dailymail.co.uk/google-news-sitemap1.xml"))
+    sitemaps = Set(new URI("https://www.dailymail.co.uk/google-news-sitemap1.xml")),
   )
 
   val WashingtonPost = Site(
     url = "https://www.washingtonpost.com/",
     datastoreId = "65742b4f9808f4c04",
-    sitemaps = Set(new URI("https://www.washingtonpost.com/arcio/news-sitemap/"))
+    sitemaps = Set(new URI("https://www.washingtonpost.com/arcio/news-sitemap/")),
   )
 
   val Telegraph = Site(
     url = "https://www.telegraph.co.uk/",
     datastoreId = "94687f1b5a1994152",
-    sitemaps = Set(new URI("https://www.telegraph.co.uk/sitemap-news.xml"))
+    sitemaps = Set(new URI("https://www.telegraph.co.uk/sitemap-news.xml")),
   )
 
-  val Sun = Site( // google-indexing-observatory-
+  val Sun = Site(
     url = "https://www.thesun.co.uk/",
     datastoreId = "943ddaf5b540f41a3",
-    sitemaps = Set(new URI("https://www.thesun.co.uk/news-sitemap.xml"))
+    sitemaps = Set(new URI("https://www.thesun.co.uk/news-sitemap.xml")),
   )
 
   val All = Set(

--- a/src/main/scala/ophan/google/indexing/observatory/model/Site.scala
+++ b/src/main/scala/ophan/google/indexing/observatory/model/Site.scala
@@ -2,7 +2,6 @@ package ophan.google.indexing.observatory.model
 
 import java.net.URI
 
-// Note, the datastore ID is only used but a connected app is still necessary for this to work
 case class Site(url: String, datastoreId: String, sitemaps: Set[URI])
 
 object Sites {

--- a/src/test/scala/ophan/google/indexing/observatory/GoogleSearchServiceTest.scala
+++ b/src/test/scala/ophan/google/indexing/observatory/GoogleSearchServiceTest.scala
@@ -22,7 +22,7 @@ class GoogleSearchServiceTest extends AnyFlatSpec with Matchers {
 
   it should "generate reliable search terms" in {
     val uri = URI.create("https://www.example.com/path/to/article")
-    val expectedTerm = "https://www.example.com/path/to/article \"/path/to/article\""
+    val expectedTerm = "example.com/path/to/article"
     GoogleSearchService.reliableSearchTermFor(uri) shouldBe expectedTerm
   }
 

--- a/src/test/scala/ophan/google/indexing/observatory/GoogleSearchServiceTest.scala
+++ b/src/test/scala/ophan/google/indexing/observatory/GoogleSearchServiceTest.scala
@@ -1,6 +1,5 @@
 package ophan.google.indexing.observatory
 
-import com.google.api.services.customsearch.v1.model.Result
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -12,9 +11,24 @@ class GoogleSearchServiceTest extends AnyFlatSpec with Matchers {
       "https://www.theguardian.com/food/2022/sep/15/korean-hotdogs-k-dogs-sausage-cheese-fast-food?utm_term=Autofeed&CMP=twt_gu&utm_medium&utm_source=Twitter"
 
     val canonicalPageUrl = URI.create("https://www.theguardian.com/food/2022/sep/15/korean-hotdogs-k-dogs-sausage-cheese-fast-food")
-    GoogleSearchService.resultMatches(canonicalPageUrl, resultWithLink(googleResultLink)) shouldBe true
+    GoogleSearchService.resultMatches(canonicalPageUrl, SearchResult(Document(DerivedStructData(googleResultLink)))) shouldBe true
   }
 
+  it should "handle URLs with special characters" in {
+    val googleResultLink = "https://www.theguardian.com/food/2023/may/15/café-review"
+    val canonicalPageUrl = URI.create("https://www.theguardian.com/food/2023/may/15/café-review")
+    GoogleSearchService.resultMatches(canonicalPageUrl, SearchResult(Document(DerivedStructData(googleResultLink)))) shouldBe true
+  }
 
-  private def resultWithLink(googleResultLink: String) = new Result().setLink(googleResultLink)
+  it should "generate reliable search terms" in {
+    val uri = URI.create("https://www.example.com/path/to/article")
+    val expectedTerm = "https://www.example.com/path/to/article \"/path/to/article\""
+    GoogleSearchService.reliableSearchTermFor(uri) shouldBe expectedTerm
+  }
+
+  it should "not match different paths on same domain" in {
+    val googleResultLink = "https://www.theguardian.com/food/different/path"
+    val canonicalPageUrl = URI.create("https://www.theguardian.com/food/original/path")
+    GoogleSearchService.resultMatches(canonicalPageUrl, SearchResult(Document(DerivedStructData(googleResultLink)))) shouldBe false
+  }
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

See issue for context: https://github.com/guardian/ophan/issues/5715

I chose to use the REST API over the Java client library for these reasons:

- The client library not compatible with API keys, only with Oauth 2.0 flow. This means a bit more work setting up service accounts and granting the right permissions to the right services.
- Given the lack of documentation, navigating the client library is time consuming and I think the trade off we get for the strong typing to just make one API call isn't worth it.

Rest docs: https://cloud.google.com/generative-ai-app-builder/docs/reference/rest

Sibling PR in other indexing repo [here](https://github.com/guardian/ophan-google-search-index-checker/pull/29).

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
