### PR TITLE
revert remove dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,13 +25,14 @@ libraryDependencies ++= Seq(
   "ch.qos.logback" % "logback-classic" % "1.5.0",
   "com.lihaoyi" %% "upickle" % "3.2.0",
   "com.squareup.okhttp3" % "okhttp" % "4.12.0",
-
   "com.madgag" %% "scala-collection-plus" % "0.11",
   "org.scanamo" %% "scanamo" % "1.0.0-M30",
   "org.scalatest" %% "scalatest" % "3.2.18" % Test,
   "org.typelevel" %% "cats-core" % catsVersion,
   "org.typelevel" %% "alleycats-core" % catsVersion,
 
+  "com.google.http-client" % "google-http-client-gson" % "1.44.1",
+  "com.google.apis" % "google-api-services-customsearch" % "v1-rev20240103-2.0.0",
   "com.bnsal" % "sitemap-parser" % "1.0.3",
   "org.typelevel" %% "literally" % "1.1.0" % Test,
 

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,6 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.2.18" % Test,
   "org.typelevel" %% "cats-core" % catsVersion,
   "org.typelevel" %% "alleycats-core" % catsVersion,
-
   "com.google.http-client" % "google-http-client-gson" % "1.44.1",
   "com.google.apis" % "google-api-services-customsearch" % "v1-rev20240103-2.0.0",
   "com.bnsal" % "sitemap-parser" % "1.0.3",

--- a/src/main/scala/ophan/google/indexing/observatory/GoogleSearchService.scala
+++ b/src/main/scala/ophan/google/indexing/observatory/GoogleSearchService.scala
@@ -1,8 +1,8 @@
 package ophan.google.indexing.observatory
 
-import upickle.default.*
 import ophan.google.indexing.observatory.logging.Logging
-import ophan.google.indexing.observatory.model.{CheckReport, PathOnly, Site, UrlAndQuotedPath, UrlOnly}
+import ophan.google.indexing.observatory.model.{CheckReport, Site}
+import upickle.default.*
 
 import java.net.URI
 import java.net.http.{HttpClient, HttpRequest}

--- a/src/main/scala/ophan/google/indexing/observatory/Lambda.scala
+++ b/src/main/scala/ophan/google/indexing/observatory/Lambda.scala
@@ -1,31 +1,18 @@
 package ophan.google.indexing.observatory
 
+import cats.data.EitherT
+import cats.implicits.*
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.events.ScheduledEvent
-import Credentials.fetchKeyFromParameterStore
+import com.gu.http.redirect.resolver.UrlResolver
+import ophan.google.indexing.observatory.Credentials.fetchKeyFromParameterStore
+import ophan.google.indexing.observatory.logging.Logging
+import ophan.google.indexing.observatory.model.Sites
 
-import java.time.Clock
-import java.time.Clock.systemUTC
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.*
 import scala.concurrent.{Await, Future}
-import com.madgag.scala.collection.decorators.*
-import ophan.google.indexing.observatory.logging.Logging
-import ophan.google.indexing.observatory.model.{AvailabilityRecord, Site, Sites}
-
-import java.net.URI
-import java.net.http.HttpClient
-import java.net.http.HttpClient.Redirect
-import java.net.http.HttpClient.Version.HTTP_2
-import java.net.http.HttpRequest
-import java.net.http.HttpResponse.BodyHandlers
-import java.time.Duration.ofSeconds
-import scala.jdk.FutureConverters.*
-import cats.data.EitherT
-import cats.implicits.*
-import com.gu.http.redirect.resolver.UrlResolver
-
-import scala.util.{Failure, Success}
+import scala.util.Success
 
 
 object Lambda extends Logging {

--- a/src/main/scala/ophan/google/indexing/observatory/model/Site.scala
+++ b/src/main/scala/ophan/google/indexing/observatory/model/Site.scala
@@ -8,11 +8,6 @@ case class Site(
                  sitemaps: Set[URI],
                )
 
-sealed trait SearchStrategy
-case object UrlOnly extends SearchStrategy
-case object PathOnly extends SearchStrategy
-case object UrlAndQuotedPath extends SearchStrategy
-
 object Sites {
   val NewYorkTimes = Site(
     url="https://www.nytimes.com/",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
