### PR TITLE
Use correct SSM param for VertexAI search key

### DIFF
--- a/src/main/scala/ophan/google/indexing/observatory/Credentials.scala
+++ b/src/main/scala/ophan/google/indexing/observatory/Credentials.scala
@@ -4,7 +4,7 @@ import ophan.google.indexing.observatory.logging.Logging
 
 case object Credentials extends Logging {
   def fetchKeyFromParameterStore(value: String): String = {
-    val paramName = s"/PROD/ophan/google-search-index-checker/$value"
+    val paramName = s"/PROD/ophan/google-search-indexing-observatory/$value"
     logger.info(Map(
       "credentials.paramName" -> paramName,
     ), s"Loading param: '$paramName'")


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

I discovered the observatory lambda was failing to start since the last release to `main`. @SHession discovered the issue was with a [lack of permission](https://github.com/guardian/google-search-indexing-observatory/blob/ed35e9b8f9effca3062f93bf0e7420c874241bc5/cdk/lib/__snapshots__/google-search-indexing-observatory.test.ts.snap#L238-L258) to fetch the VertexAI search key. I have created a new parameter with the search key where the path is relevant to this app and we have the right permissions.

## How to test

Have deployed this branch to PROD and asserted the lambda is now running and working as expected.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
